### PR TITLE
Handle bad request, and better handle unknown errors

### DIFF
--- a/twistes/client.py
+++ b/twistes/client.py
@@ -1,12 +1,13 @@
 import treq
 import json
-
 from twisted.internet.defer import inlineCallbacks, returnValue, CancelledError
 from twisted.internet.error import ConnectingCancelledError
 from twisted.web._newclient import ResponseNeverReceived
-
 from twistes.compatability import string_types
-from twistes.exceptions import NotFoundError, ConnectionTimeout
+from twistes.exceptions import (NotFoundError,
+                                ConnectionTimeout,
+                                RequestError,
+                                ElasticsearchException)
 from twistes.scroller import Scroller
 from twistes.consts import HttpMethod, EsMethods, EsConst, NULL_VALUES
 from twistes.parser import EsParser
@@ -72,7 +73,9 @@ class Elasticsearch(object):
         """
         self._es_parser.is_not_empty_params(index, doc_type, id)
         path = self._es_parser.make_path(index, doc_type, id)
-        result = yield self._perform_request(HttpMethod.HEAD, path, params=query_params)
+        result = yield self._perform_request(HttpMethod.HEAD,
+                                             path,
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -103,7 +106,9 @@ class Elasticsearch(object):
         """
         self._es_parser.is_not_empty_params(index, doc_type, id)
         path = self._es_parser.make_path(index, doc_type, id, EsMethods.SOURCE)
-        result = yield self._perform_request(HttpMethod.GET, path, params=query_params)
+        result = yield self._perform_request(HttpMethod.GET,
+                                             path,
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -131,8 +136,15 @@ class Elasticsearch(object):
             performing the operation
         """
         self._es_parser.is_not_empty_params(body)
-        path = self._es_parser.make_path(index, doc_type, EsMethods.MULTIPLE_GET)
-        result = yield self._perform_request(HttpMethod.GET, path, body=body, params=query_params)
+
+        path = self._es_parser.make_path(index,
+                                         doc_type,
+                                         EsMethods.MULTIPLE_GET)
+
+        result = yield self._perform_request(HttpMethod.GET,
+                                             path,
+                                             body=body,
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -282,8 +294,15 @@ class Elasticsearch(object):
         """
         self._es_parser.is_not_empty_params(index, doc_type, id)
 
-        path = self._es_parser.make_path(index, doc_type, id, EsMethods.EXPLAIN)
-        result = yield self._perform_request(HttpMethod.GET, path, body, params=query_params)
+        path = self._es_parser.make_path(index,
+                                         doc_type,
+                                         id,
+                                         EsMethods.EXPLAIN)
+
+        result = yield self._perform_request(HttpMethod.GET,
+                                             path,
+                                             body,
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -441,7 +460,12 @@ class Elasticsearch(object):
         if not preserve_order:
             kwargs['search_type'] = 'scan'
         # initial search
-        results = yield self.search(index=index, doc_type=doc_type, body=query,size=size, scroll=scroll, **kwargs)
+        results = yield self.search(index=index,
+                                    doc_type=doc_type,
+                                    body=query,
+                                    size=size,
+                                    scroll=scroll,
+                                    **kwargs)
 
         returnValue(Scroller(self, results, scroll, size))
 
@@ -509,7 +533,10 @@ class Elasticsearch(object):
         """
         self._es_parser.is_not_empty_params(body)
         path = self._es_parser.make_path(index, doc_type, EsMethods.BULK)
-        result = yield self._perform_request(HttpMethod.POST, path, self._bulk_body(body), params=query_params)
+        result = yield self._perform_request(HttpMethod.POST,
+                                             path,
+                                             self._bulk_body(body),
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -527,8 +554,14 @@ class Elasticsearch(object):
             'dfs_query_and_fetch'
         """
         self._es_parser.is_not_empty_params(body)
-        path = self._es_parser.make_path(index, doc_type, EsMethods.MULTIPLE_SEARCH)
-        result = yield self._perform_request(HttpMethod.GET, path, self._bulk_body(body), params=query_params)
+        path = self._es_parser.make_path(index,
+                                         doc_type,
+                                         EsMethods.MULTIPLE_SEARCH)
+
+        result = yield self._perform_request(HttpMethod.GET,
+                                             path,
+                                             self._bulk_body(body),
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -538,27 +571,50 @@ class Elasticsearch(object):
         if body is not None and not isinstance(body, string_types):
             body = json.dumps(body)
         try:
-            response = yield self._async_http_client.request(method, url, data=body, timeout=self._timeout,
+            response = yield self._async_http_client.request(method,
+                                                             url,
+                                                             data=body,
+                                                             timeout=self._timeout,
                                                              auth=self._auth)
-            if response.code in (ResponseCodes.OK, ResponseCodes.CREATED, ResponseCodes.ACCEPTED):
-                content = yield self._get_content(response)
+
+            content = yield self._get_content(response)
+
+            if response.code in (ResponseCodes.OK,
+                                 ResponseCodes.CREATED,
+                                 ResponseCodes.ACCEPTED):
                 returnValue(content)
-            elif response.code == ResponseCodes.NOT_FOUND:
+
+            if response.code == ResponseCodes.NOT_FOUND:
                 raise NotFoundError()
-            else:
-                # This is a place holder that will change after we implement the whole Es interface
-                raise Exception(response.code)
-        except (ResponseNeverReceived, CancelledError, ConnectingCancelledError):
+
+            if response.code == ResponseCodes.BAD_REQUEST:
+                raise RequestError("bad request", content)
+
+            # This is a place holder for unknown exceptions
+            # that haven't been encaplulated yet
+            msg_fmt = "unknown error; code: {code} | message: {msg}"
+            raise ElasticsearchException(msg_fmt.format(code=response.code,
+                                                        msg=str(content)))
+
+        except (ResponseNeverReceived,
+                CancelledError,
+                ConnectingCancelledError):
             raise ConnectionTimeout()
 
     @inlineCallbacks
     def _get_content(self, response):
+        content = None
         try:
             content = yield response.json()
         except ValueError as e:
-            content = yield response.content()
-            content = json.loads(content)
-        returnValue(content) if content else returnValue(None)
+            content_txt = yield response.content()
+            content = json.loads(content_txt)
+        except Exception as e:
+            # unknown exceptions are ignored
+            # and the content is set to None
+            pass
+        finally:
+            returnValue(content)
 
     @staticmethod
     def _bulk_body(body):

--- a/twistes/client.py
+++ b/twistes/client.py
@@ -588,10 +588,10 @@ class Elasticsearch(object):
                 raise NotFoundError()
 
             if response.code == ResponseCodes.BAD_REQUEST:
-                raise RequestError("bad request", content)
+                raise RequestError("bad request on: {}".format(url), content)
 
             # This is a place holder for unknown exceptions
-            # that haven't been encaplulated yet
+            # that haven't been encapsulated yet
             msg_fmt = "unknown error; code: {code} | message: {msg}"
             raise ElasticsearchException(msg_fmt.format(code=response.code,
                                                         msg=str(content)))

--- a/twistes/exceptions.py
+++ b/twistes/exceptions.py
@@ -5,6 +5,16 @@ class ElasticsearchException(Exception):
     """
 
 
+class RequestError(ElasticsearchException):
+    """
+    Exception raised when ES returns an 400 status code
+    """
+
+    def __init__(self, message, error):
+        super(RequestError, self).__init__(message)
+        self.error = error
+
+
 class TransportError(ElasticsearchException):
     """`
     Exception raised when ES returns a non-OK (>=400) HTTP status code. Or when
@@ -25,6 +35,7 @@ class ScanError(ElasticsearchException):
 
 
 class BulkIndexError(ElasticsearchException):
+
     @property
     def errors(self):
         """ List of errors from execution of the last chunk. """


### PR DESCRIPTION
Added code to handle bad request (https://github.com/avihad/twistes/issues/29), which will now raise an `RequestError` exception.
`RequestError` has an `error` field that holds the value that was returned by elasticsearch.

Furthermore, added code that handles unknown errors (https://github.com/avihad/twistes/pull/30)
