### PR TITLE
Refactor exceptions to be more similar to elasticsearch-py

### DIFF
--- a/tests/test_bulk_utility.py
+++ b/tests/test_bulk_utility.py
@@ -22,51 +22,62 @@ ITEM_SUCCESS = (True, None)
 
 
 class TestBulkUtility(TestCase):
+
     def setUp(self):
         self.bulk_utility = BulkUtility(MagicMock())
 
     @inlineCallbacks
     def test_bulk_stats_only(self):
-        self.bulk_utility.streaming_bulk = MagicMock(return_value=[succeed([ITEM_SUCCESS, ITEM_SUCCESS, ITEM_FAILED])])
+        return_value = [succeed([ITEM_SUCCESS, ITEM_SUCCESS, ITEM_FAILED])]
+        self.bulk_utility.streaming_bulk = MagicMock(return_value=return_value)
         success, faileds = yield self.bulk_utility.bulk(None, stats_only=True)
         self.assertEqual(2, success)
         self.assertEqual(1, faileds)
 
     @inlineCallbacks
     def test_bulk(self):
-        self.bulk_utility.streaming_bulk = MagicMock(return_value=[succeed([ITEM_SUCCESS, ITEM_SUCCESS, ITEM_FAILED])])
+        return_value = [succeed([ITEM_SUCCESS, ITEM_SUCCESS, ITEM_FAILED])]
+        self.bulk_utility.streaming_bulk = MagicMock(return_value=return_value)
         errors = yield self.bulk_utility.bulk(None)
         self.assertEqual((2, [ERROR_MSG]), errors)
 
     def test_streaming_bulk(self):
         self.bulk_utility._process_bulk_chunk = MagicMock()
         num_of_actions = 30
-        actions = [i for i in range(num_of_actions)]
         mock_sub_actions = [1, 2, 3]
         num_of_chunks = 4
-        self.bulk_utility._chunk_actions = MagicMock(return_value=[mock_sub_actions for i in range(num_of_chunks)])
-        expand_action_callback = MagicMock()
-        for d in self.bulk_utility.streaming_bulk(actions, expand_action_callback=expand_action_callback):
-            pass
+        return_value = [mock_sub_actions for i in range(num_of_chunks)]
+        self.bulk_utility._chunk_actions = MagicMock(return_value=return_value)
 
-        self.assertEqual(num_of_actions, expand_action_callback.call_count)
-        self.assertEqual(num_of_chunks, self.bulk_utility._process_bulk_chunk.call_count)
+        cb = MagicMock()
+
+        bulk = list(self.bulk_utility.streaming_bulk(range(num_of_actions),
+                                                     expand_action_callback=cb))
+
+        self.assertEqual(num_of_actions,
+                         cb.call_count)
+        self.assertEqual(num_of_chunks,
+                         self.bulk_utility._process_bulk_chunk.call_count)
 
     def test_action_parser(self):
-        update_record = {EsBulk.OP_TYPE: EsBulk.UPDATE, EsDocProperties.INDEX: SOME_INDEX,
-                         EsDocProperties.TYPE: SOME_DOC_TYPE, EsDocProperties.ID: SOME_ID,
+        update_record = {EsBulk.OP_TYPE: EsBulk.UPDATE,
+                         EsDocProperties.INDEX: SOME_INDEX,
+                         EsDocProperties.TYPE: SOME_DOC_TYPE,
+                         EsDocProperties.ID: SOME_ID,
                          EsDocProperties.SOURCE: SOME_DOC}
 
         result = ActionParser.expand_action(update_record)
-
-        expected = (self._create_action_row(EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID), SOME_DOC)
+        row = [EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID]
+        expected = (self._create_action_row(*row), SOME_DOC)
 
         self.assertEqual(expected, result)
 
     @staticmethod
     def _create_action_row(op_type, index, doc_type, id):
-        return {op_type: {EsDocProperties.INDEX: index, EsDocProperties.TYPE: doc_type,
-                          EsDocProperties.ID: id}}
+        return {op_type: {EsDocProperties.INDEX: index,
+                          EsDocProperties.TYPE: doc_type,
+                          EsDocProperties.ID: id}
+                }
 
     def test__expand_action_doc_str(self):
         doc_dumps = json.dumps(SOME_DOC)
@@ -78,37 +89,53 @@ class TestBulkUtility(TestCase):
         self.assertEqual(expected, result)
 
     def test__expand_action_delete(self):
-        delete_record = {EsBulk.OP_TYPE: EsBulk.DELETE, EsDocProperties.INDEX: SOME_INDEX,
-                         EsDocProperties.TYPE: SOME_DOC_TYPE, EsDocProperties.ID: SOME_ID}
+        delete_record = {EsBulk.OP_TYPE: EsBulk.DELETE,
+                         EsDocProperties.INDEX: SOME_INDEX,
+                         EsDocProperties.TYPE: SOME_DOC_TYPE,
+                         EsDocProperties.ID: SOME_ID}
 
         result = ActionParser.expand_action(delete_record)
-
-        expected = (self._create_action_row(EsBulk.DELETE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID), None)
+        row = [EsBulk.DELETE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID]
+        expected = (self._create_action_row(*row), None)
 
         self.assertEqual(expected, result)
 
     def test__chunk_actions_by_chunk_size(self):
         num_of_tasks = 10
-        actions = [(self._create_action_row(EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID), SOME_DOC) for i in
-                   range(num_of_tasks)]
-        num_of_tasks_per_chunk = 3
-        chunks = [c for c in
-                  self.bulk_utility._chunk_actions(actions, chunk_size=num_of_tasks_per_chunk, max_chunk_bytes=100000)]
-        self.assertEqual(math.ceil(num_of_tasks / num_of_tasks_per_chunk), len(chunks))
+        tasks_per_chunk = 3
+
+        row = [EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID]
+
+        actions = [(self._create_action_row(*row), SOME_DOC)
+                   for i in range(num_of_tasks)]
+
+        chunks = list(self.bulk_utility._chunk_actions(actions,
+                                                       chunk_size=tasks_per_chunk,
+                                                       max_chunk_bytes=100000))
+        self.assertEqual(math.ceil(num_of_tasks / tasks_per_chunk),
+                         len(chunks))
 
     def test__chunk_actions_by_chunk_bytes(self):
         num_of_tasks = 10
-        actions = [(self._create_action_row(EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID), SOME_DOC) for i in
+        row = [EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID]
+        actions = [(self._create_action_row(*row), SOME_DOC) for _ in
                    range(num_of_tasks)]
-        chunks = [c for c in self.bulk_utility._chunk_actions(actions, chunk_size=20, max_chunk_bytes=350)]
+
+        chunks = list(self.bulk_utility._chunk_actions(actions,
+                                                       chunk_size=20,
+                                                       max_chunk_bytes=350))
+
         # Every 2 records is about 350 bytes so we will have 5 chunks
         self.assertEqual(5, len(chunks))
 
     def test__chunk_actions_serialize(self):
         num_of_tasks = 10
-        actions = [(self._create_action_row(EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID), SOME_DOC) for i in
+        row = [EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID]
+        actions = [(self._create_action_row(*row), SOME_DOC) for _ in
                    range(num_of_tasks)]
-        chunks = [c for c in self.bulk_utility._chunk_actions(actions, chunk_size=20, max_chunk_bytes=100000)]
+        chunks = list(self.bulk_utility._chunk_actions(actions,
+                                                       chunk_size=20,
+                                                       max_chunk_bytes=100000))
         # Every 2 records is about 350 bytes so we will have 5 chunks
         expected = []
         for a, d in actions:
@@ -123,12 +150,18 @@ class TestBulkUtility(TestCase):
         op_type2 = EsBulk.DELETE
         good_index_result = {op_type1: {'status': 200}}
         good_delete_result = {op_type2: {'status': 200}}
-        bulk_mock_result = {'items': [good_index_result.copy(), good_delete_result.copy()]}
+        bulk_mock_result = {'items': [good_index_result.copy(),
+                                      good_delete_result.copy()]}
 
-        self.bulk_utility.client.bulk = MagicMock(return_value=bulk_mock_result)
-        actions = [self._create_action_row(op_type1, SOME_INDEX, SOME_DOC_TYPE, SOME_ID)]
+        self.bulk_utility.client.bulk = MagicMock(
+            return_value=bulk_mock_result)
+
+        row = [op_type1, SOME_INDEX, SOME_DOC_TYPE, SOME_ID]
+        actions = [self._create_action_row(*row)]
+
         results = yield self.bulk_utility._process_bulk_chunk(json.dumps(actions))
-        self.assertEqual([(True, good_index_result), (True, good_delete_result)], results)
+        self.assertEqual([(True, good_index_result),
+                          (True, good_delete_result)], results)
 
     @inlineCallbacks
     def test__process_bulk_chunk(self):
@@ -136,12 +169,17 @@ class TestBulkUtility(TestCase):
         op_type2 = EsBulk.DELETE
         good_index_result = {op_type1: {'status': 200}}
         good_delete_result = {op_type2: {'status': 200}}
-        bulk_mock_result = {'items': [good_index_result.copy(), good_delete_result.copy()]}
+        bulk_mock_result = {'items': [good_index_result.copy(),
+                                      good_delete_result.copy()]}
 
-        self.bulk_utility.client.bulk = MagicMock(return_value=bulk_mock_result)
-        actions = [self._create_action_row(op_type1, SOME_INDEX, SOME_DOC_TYPE, SOME_ID)]
+        self.bulk_utility.client.bulk = MagicMock(
+            return_value=bulk_mock_result)
+        row = [op_type1, SOME_INDEX, SOME_DOC_TYPE, SOME_ID]
+        actions = [self._create_action_row(*row)]
         results = yield self.bulk_utility._process_bulk_chunk(json.dumps(actions))
-        self.assertEqual([(True, good_index_result), (True, good_delete_result)], results)
+        self.assertEqual([(True, good_index_result),
+                          (True, good_delete_result)],
+                         results)
 
     @inlineCallbacks
     def test__process_bulk_chunk_error(self):
@@ -151,30 +189,41 @@ class TestBulkUtility(TestCase):
         bad_delete_result = {op_type2: {'status': 500}}
         bulk_mock_result = {'items': [good_index_result, bad_delete_result]}
 
-        self.bulk_utility.client.bulk = MagicMock(return_value=bulk_mock_result)
-        actions = [self._create_action_row(op_type1, SOME_INDEX, SOME_DOC_TYPE, SOME_ID)]
-        yield self.assertFailure(self.bulk_utility._process_bulk_chunk(json.dumps(actions)), BulkIndexError)
+        self.bulk_utility.client.bulk = MagicMock(
+            return_value=bulk_mock_result)
+        row = [op_type1, SOME_INDEX, SOME_DOC_TYPE, SOME_ID]
+        actions = [self._create_action_row(*row)]
+        yield self.assertFailure(self.bulk_utility._process_bulk_chunk(json.dumps(actions)),
+                                 BulkIndexError)
 
     @inlineCallbacks
     def test__process_bulk_connection_timeout_raise(self):
-        self.bulk_utility.client.bulk = MagicMock(side_effect=ConnectionTimeout)
+        self.bulk_utility.client.bulk = MagicMock(
+            side_effect=ConnectionTimeout("test-timeout"))
         self.bulk_utility._handle_transport_error = MagicMock()
-        yield self.assertFailure(self.bulk_utility._process_bulk_chunk([]), ConnectionTimeout)
+        yield self.assertFailure(self.bulk_utility._process_bulk_chunk([]),
+                                 ConnectionTimeout)
 
     @inlineCallbacks
     def test__process_bulk_transport_error_raise_false(self):
-        self.bulk_utility.client.bulk = MagicMock(side_effect=ConnectionTimeout)
+        self.bulk_utility.client.bulk = MagicMock(
+            side_effect=ConnectionTimeout("test-timeout"))
         self.bulk_utility._handle_transport_error = MagicMock()
-        results = yield self.bulk_utility._process_bulk_chunk([], raise_on_exception=False)
+        results = yield self.bulk_utility._process_bulk_chunk([],
+                                                              raise_on_exception=False)
         self.assertEqual([], results)
 
     def test__handle_transport_error(self):
-        actions = [(self._create_action_row(EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID), SOME_DOC) for i in
+        row = [EsBulk.UPDATE, SOME_INDEX, SOME_DOC_TYPE, SOME_ID]
+        actions = [(self._create_action_row(*row), SOME_DOC) for i in
                    range(10)]
         dump_actions = []
         for a, d in actions:
             dump_actions.append(json.dumps(a))
             dump_actions.append(json.dumps(d))
 
-        self.assertRaises(BulkIndexError, self.bulk_utility._handle_transport_error, dump_actions, Exception(),
+        self.assertRaises(BulkIndexError,
+                          self.bulk_utility._handle_transport_error,
+                          dump_actions,
+                          Exception(),
                           raise_on_error=True)

--- a/twistes/client.py
+++ b/twistes/client.py
@@ -1,12 +1,13 @@
 import treq
 import json
-
 from twisted.internet.defer import inlineCallbacks, returnValue, CancelledError
 from twisted.internet.error import ConnectingCancelledError
 from twisted.web._newclient import ResponseNeverReceived
-
 from twistes.compatability import string_types
-from twistes.exceptions import NotFoundError, ConnectionTimeout
+from twistes.exceptions import (NotFoundError,
+                                ConnectionTimeout,
+                                RequestError,
+                                ElasticsearchException)
 from twistes.scroller import Scroller
 from twistes.consts import HttpMethod, EsMethods, EsConst, NULL_VALUES
 from twistes.parser import EsParser
@@ -72,7 +73,9 @@ class Elasticsearch(object):
         """
         self._es_parser.is_not_empty_params(index, doc_type, id)
         path = self._es_parser.make_path(index, doc_type, id)
-        result = yield self._perform_request(HttpMethod.HEAD, path, params=query_params)
+        result = yield self._perform_request(HttpMethod.HEAD,
+                                             path,
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -103,7 +106,9 @@ class Elasticsearch(object):
         """
         self._es_parser.is_not_empty_params(index, doc_type, id)
         path = self._es_parser.make_path(index, doc_type, id, EsMethods.SOURCE)
-        result = yield self._perform_request(HttpMethod.GET, path, params=query_params)
+        result = yield self._perform_request(HttpMethod.GET,
+                                             path,
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -131,8 +136,15 @@ class Elasticsearch(object):
             performing the operation
         """
         self._es_parser.is_not_empty_params(body)
-        path = self._es_parser.make_path(index, doc_type, EsMethods.MULTIPLE_GET)
-        result = yield self._perform_request(HttpMethod.GET, path, body=body, params=query_params)
+
+        path = self._es_parser.make_path(index,
+                                         doc_type,
+                                         EsMethods.MULTIPLE_GET)
+
+        result = yield self._perform_request(HttpMethod.GET,
+                                             path,
+                                             body=body,
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -282,8 +294,15 @@ class Elasticsearch(object):
         """
         self._es_parser.is_not_empty_params(index, doc_type, id)
 
-        path = self._es_parser.make_path(index, doc_type, id, EsMethods.EXPLAIN)
-        result = yield self._perform_request(HttpMethod.GET, path, body, params=query_params)
+        path = self._es_parser.make_path(index,
+                                         doc_type,
+                                         id,
+                                         EsMethods.EXPLAIN)
+
+        result = yield self._perform_request(HttpMethod.GET,
+                                             path,
+                                             body,
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -441,7 +460,12 @@ class Elasticsearch(object):
         if not preserve_order:
             kwargs['search_type'] = 'scan'
         # initial search
-        results = yield self.search(index=index, doc_type=doc_type, body=query,size=size, scroll=scroll, **kwargs)
+        results = yield self.search(index=index,
+                                    doc_type=doc_type,
+                                    body=query,
+                                    size=size,
+                                    scroll=scroll,
+                                    **kwargs)
 
         returnValue(Scroller(self, results, scroll, size))
 
@@ -509,7 +533,10 @@ class Elasticsearch(object):
         """
         self._es_parser.is_not_empty_params(body)
         path = self._es_parser.make_path(index, doc_type, EsMethods.BULK)
-        result = yield self._perform_request(HttpMethod.POST, path, self._bulk_body(body), params=query_params)
+        result = yield self._perform_request(HttpMethod.POST,
+                                             path,
+                                             self._bulk_body(body),
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -527,8 +554,14 @@ class Elasticsearch(object):
             'dfs_query_and_fetch'
         """
         self._es_parser.is_not_empty_params(body)
-        path = self._es_parser.make_path(index, doc_type, EsMethods.MULTIPLE_SEARCH)
-        result = yield self._perform_request(HttpMethod.GET, path, self._bulk_body(body), params=query_params)
+        path = self._es_parser.make_path(index,
+                                         doc_type,
+                                         EsMethods.MULTIPLE_SEARCH)
+
+        result = yield self._perform_request(HttpMethod.GET,
+                                             path,
+                                             self._bulk_body(body),
+                                             params=query_params)
         returnValue(result)
 
     @inlineCallbacks
@@ -538,27 +571,50 @@ class Elasticsearch(object):
         if body is not None and not isinstance(body, string_types):
             body = json.dumps(body)
         try:
-            response = yield self._async_http_client.request(method, url, data=body, timeout=self._timeout,
+            response = yield self._async_http_client.request(method,
+                                                             url,
+                                                             data=body,
+                                                             timeout=self._timeout,
                                                              auth=self._auth)
-            if response.code in (ResponseCodes.OK, ResponseCodes.CREATED, ResponseCodes.ACCEPTED):
-                content = yield self._get_content(response)
+
+            content = yield self._get_content(response)
+
+            if response.code in (ResponseCodes.OK,
+                                 ResponseCodes.CREATED,
+                                 ResponseCodes.ACCEPTED):
                 returnValue(content)
-            elif response.code == ResponseCodes.NOT_FOUND:
+
+            if response.code == ResponseCodes.NOT_FOUND:
                 raise NotFoundError()
-            else:
-                # This is a place holder that will change after we implement the whole Es interface
-                raise Exception(response.code)
-        except (ResponseNeverReceived, CancelledError, ConnectingCancelledError):
+
+            if response.code == ResponseCodes.BAD_REQUEST:
+                raise RequestError("bad request", content)
+
+            # This is a place holder for unknown exceptions
+            # that haven't been encaplulated yet
+            msg_fmt = "unknown error; code: {code} | message: {msg}"
+            raise ElasticsearchException(msg_fmt.format(code=response.code,
+                                                        msg=str(content)))
+
+        except (ResponseNeverReceived,
+                CancelledError,
+                ConnectingCancelledError):
             raise ConnectionTimeout()
 
     @inlineCallbacks
     def _get_content(self, response):
+        content = None
         try:
             content = yield response.json()
         except ValueError as e:
-            content = yield response.content()
-            content = json.loads(content)
-        returnValue(content) if content else returnValue(None)
+            content_txt = yield response.content()
+            content = json.loads(content_txt)
+        except Exception as e:
+            # unknown exceptions are ignored
+            # and the content is set to None
+            pass
+        finally:
+            returnValue(content)
 
     @staticmethod
     def _bulk_body(body):

--- a/twistes/client.py
+++ b/twistes/client.py
@@ -585,10 +585,10 @@ class Elasticsearch(object):
                 returnValue(content)
 
             if response.code == ResponseCodes.NOT_FOUND:
-                raise NotFoundError()
+                raise NotFoundError(content)
 
             if response.code == ResponseCodes.BAD_REQUEST:
-                raise RequestError("bad request", content)
+                raise RequestError(content)
 
             # This is a place holder for unknown exceptions
             # that haven't been encaplulated yet
@@ -598,8 +598,8 @@ class Elasticsearch(object):
 
         except (ResponseNeverReceived,
                 CancelledError,
-                ConnectingCancelledError):
-            raise ConnectionTimeout()
+                ConnectingCancelledError) as e:
+            raise ConnectionTimeout(str(e))
 
     @inlineCallbacks
     def _get_content(self, response):

--- a/twistes/exceptions.py
+++ b/twistes/exceptions.py
@@ -5,6 +5,16 @@ class ElasticsearchException(Exception):
     """
 
 
+class RequestError(ElasticsearchException):
+    """
+    Exception raised when ES returns an 400 status code
+    """
+
+    def __init__(self, message, error):
+        super(RequestError, self).__init__(message)
+        self.error = error
+
+
 class TransportError(ElasticsearchException):
     """`
     Exception raised when ES returns a non-OK (>=400) HTTP status code. Or when
@@ -25,6 +35,7 @@ class ScanError(ElasticsearchException):
 
 
 class BulkIndexError(ElasticsearchException):
+
     @property
     def errors(self):
         """ List of errors from execution of the last chunk. """


### PR DESCRIPTION
Copied the same exception hierarchy and codes as the original elasticsearch-py.
