### PR TITLE
add retry on timeout to client

### DIFF
--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -1,0 +1,55 @@
+
+from twisted.internet.defer import inlineCallbacks
+from twisted.trial.unittest import TestCase
+from mock import MagicMock
+from twisted.web._newclient import ResponseNeverReceived
+
+from twistes.client import Elasticsearch
+from twistes.consts import ResponseCodes
+from twistes.exceptions import ConnectionTimeout
+
+SOME_HOSTS_CONFIG = [{
+    'host': "http://SOME_HOST",
+    'port': 9200,
+    'http_auth': '{user}:{pwd}'.format(user="BURN", pwd="SANDERS")
+}]
+
+METHOD = "method"
+PATH = "/path"
+BODY = {"some": "json"}
+SOME_CONTENT = "Some content"
+
+NUM_RETRIES = 3
+
+
+class TestRetries(TestCase):
+
+    @inlineCallbacks
+    def test_perform_request_fail(self):
+        async_http_client = MagicMock()
+        async_http_client.request = MagicMock(side_effect=ResponseNeverReceived("test"))
+        es = self.get_es(async_http_client)
+
+        yield self.assertFailure(es._perform_request(METHOD, PATH, BODY), ConnectionTimeout)
+        self.assertEqual(NUM_RETRIES + 1, async_http_client.request.call_count)
+
+    @inlineCallbacks
+    def test_perform_request_success(self):
+        async_http_client = MagicMock()
+        async_http_client.request = MagicMock(return_value=self.generate_response(ResponseCodes.OK))
+
+        es = self.get_es(async_http_client)
+        es._get_content = MagicMock(return_value=SOME_CONTENT)
+
+        r = yield es._perform_request(METHOD, PATH, BODY)
+        self.assertEqual(SOME_CONTENT, r)
+
+    @staticmethod
+    def generate_response(response_code):
+        response = MagicMock()
+        response.code = response_code
+        return response
+
+    @staticmethod
+    def get_es(async_http_client):
+        return Elasticsearch(SOME_HOSTS_CONFIG, 10, async_http_client, None, True, NUM_RETRIES)

--- a/twistes/client.py
+++ b/twistes/client.py
@@ -618,14 +618,14 @@ class Elasticsearch(object):
                 raise RequestError(content)
 
             # This is a place holder for unknown exceptions
-            # that haven't been encaplulated yet
+            # that haven't been encapsulated yet
             msg_fmt = "unknown error; code: {code} | message: {msg}"
             raise ElasticsearchException(msg_fmt.format(code=response.code,
                                                         msg=str(content)))
 
         except ResponseNeverReceived as e:
 
-            if self._retry_on_timeout and num_retries >= 0:
+            if self._retry_on_timeout and num_retries > 0:
                 response = yield self._perform_request(method, path, body, params, num_retries - 1)
                 returnValue(response)
 


### PR DESCRIPTION
allow a retry to deal with `ResponseNeverReceived` error